### PR TITLE
Allow target name to display (translated) in "Global metadata" tab

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -41,7 +41,7 @@ prose:
             label: "Indicator number"
             translation_key: metadata_fields.indicator
             scope: global
-      - name: "target"
+      - name: "target_name"
         field:
             element: text
             label: "Target name"

--- a/meta/1-1-1.md
+++ b/meta/1-1-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 01-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, eradicate extreme poverty for all people everywhere, currently measured
-  as people living on less than $1.25 a day
+target_name: global_targets.1-1-title
 target_id: '1.1'
 un_custodian_agency: World Bank
 un_designated_tier: '1'

--- a/meta/1-2-1.md
+++ b/meta/1-2-1.md
@@ -15,8 +15,7 @@ indicator_sort_order: 01-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, reduce at least by half the proportion of men, women and children
-  of all ages living in poverty in all its dimensions according to national definitions.
+target_name: global_targets.1-2-title
 target_id: '1.2'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '1'

--- a/meta/1-2-2.md
+++ b/meta/1-2-2.md
@@ -15,8 +15,7 @@ indicator_sort_order: 01-02-02
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, reduce at least by half the proportion of men, women and children
-  of all ages living in poverty in all its dimensions according to national definitions
+target_name: global_targets.1-2-title
 target_id: '1.2'
 un_custodian_agency: United Nations Children's Fund (UNICEFF) World Bank (WB) United
   Nations Development Programme (UNDP)

--- a/meta/1-3-1.md
+++ b/meta/1-3-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 01-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: Implement nationally appropriate social protection systems and measures for
-  all, including floors, and by 2030 achieve substantial coverage of the poor and
-  the vulnerable
+target_name: global_targets.1-3-title
 target_id: '1.3'
 un_custodian_agency: ILO
 un_designated_tier: '2'

--- a/meta/1-4-1.md
+++ b/meta/1-4-1.md
@@ -10,10 +10,7 @@ indicator_sort_order: 01-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, ensure that all men and women, in particular the poor and the vulnerable,
-  have equal rights to economic resources, as well as access to basic services, ownership
-  and control over land and other forms of property, inheritance, natural resources,
-  appropriate new technology and financial services, including microfinance.
+target_name: global_targets.1-4-title
 target_id: '1.4'
 un_custodian_agency: UN-Habitat
 un_designated_tier: '3'

--- a/meta/1-4-2.md
+++ b/meta/1-4-2.md
@@ -11,10 +11,7 @@ indicator_sort_order: 01-04-02
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, ensure that all men and women, in particular the poor and the vulnerable,
-  have equal rights to economic resources, as well as access to basic services, ownership
-  and control over land and other forms of property, inheritance, natural resources,
-  appropriate new technology and financial services, including microfinance.
+target_name: global_targets.1-4-title
 target_id: '1.4'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '2'

--- a/meta/1-5-1.md
+++ b/meta/1-5-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 01-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, build the resilience of the poor and those in vulnerable situations
-  and reduce their exposure and vulnerability to climate-related extreme events and
-  other economic, social and environmental shocks and disasters
+target_name: global_targets.1-5-title
 target_id: '1.5'
 un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
 un_designated_tier: '2'

--- a/meta/1-5-2.md
+++ b/meta/1-5-2.md
@@ -10,9 +10,7 @@ indicator_sort_order: 01-05-02
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, build the resilience of the poor and those in vulnerable situations
-  and reduce their exposure and vulnerability to climate-related extreme events and
-  other economic, social and environmental shocks and disasters
+target_name: global_targets.1-5-title
 target_id: '1.5'
 un_custodian_agency: UNISDR
 un_designated_tier: '2'

--- a/meta/1-5-3.md
+++ b/meta/1-5-3.md
@@ -10,9 +10,7 @@ indicator_sort_order: 01-05-03
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, build the resilience of the poor and those in vulnerable situations
-  and reduce their exposure and vulnerability to climate-related extreme events and
-  other economic, social and environmental shocks and disasters
+target_name: global_targets.1-5-title
 target_id: '1.5'
 un_custodian_agency: UNISDR
 un_designated_tier: '1'

--- a/meta/1-5-4.md
+++ b/meta/1-5-4.md
@@ -9,9 +9,7 @@ indicator_sort_order: 01-05-04
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, build the resilience of the poor and those in vulnerable situations
-  and reduce their exposure and vulnerability to climate-related extreme events and
-  other economic, social and environmental shocks and disasters
+target_name: global_targets.1-5-title
 target_id: '1.5'
 un_custodian_agency: UNISDR
 un_designated_tier: '2'

--- a/meta/1-a-1.md
+++ b/meta/1-a-1.md
@@ -10,10 +10,7 @@ indicator_sort_order: 01-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: Ensure significant mobilization of resources from a variety of sources, including
-  through enhanced development cooperation, in order to provide adequate and predictable
-  means for developing countries, in particular least developed countries, to implement
-  programmes and policies to end poverty in all its dimensions
+target_name: global_targets.1-a-title
 target_id: 1.a
 un_designated_tier: '3'
 ---

--- a/meta/1-a-2.md
+++ b/meta/1-a-2.md
@@ -10,10 +10,7 @@ indicator_sort_order: 01-aa-02
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: Ensure significant mobilization of resources from a variety of sources, including
-  through enhanced development cooperation, in order to provide adequate and predictable
-  means for developing countries, in particular least developed countries, to implement
-  programmes and policies to end poverty in all its dimensions
+target_name: global_targets.1-a-title
 target_id: 1.a
 un_custodian_agency: Discussions are occurring between the following organisations
   International Labour Organization (ILO) United Nations Educational Scientific and

--- a/meta/1-a-3.md
+++ b/meta/1-a-3.md
@@ -9,10 +9,7 @@ indicator_sort_order: 01-aa-03
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: Ensure significant mobilization of resources from a variety of sources, including
-  through enhanced development cooperation, in order to provide adequate and predictable
-  means for developing countries, in particular least developed countries, to implement
-  programmes and policies to end poverty in all its dimensions
+target_name: global_targets.1-a-title
 target_id: 1.a
 un_designated_tier: '3'
 ---

--- a/meta/1-b-1.md
+++ b/meta/1-b-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 01-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: Create sound policy frameworks at the national, regional and international
-  levels, based on pro-poor and gender-sensitive development strategies, to support
-  accelerated investment in poverty eradication actions
+target_name: global_targets.1-b-title
 target_id: 1.b
 un_designated_tier: '3'
 ---

--- a/meta/10-1-1.md
+++ b/meta/10-1-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 10-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: 10.1 By 2030, progressively achieve and sustain income growth of the bottom
-  40 per cent of the population at a rate higher than the national average
+target_name: global_targets.10-1-title
 target_id: '10.1'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: 2

--- a/meta/10-2-1.md
+++ b/meta/10-2-1.md
@@ -18,9 +18,7 @@ indicator_sort_order: 10-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: By 2030, empower and promote the social, economic and political inclusion
-  of all, irrespective of age, sex, disability, race, ethnicity, origin, religion
-  or economic or other status
+target_name: global_targets.10-2-title
 target_id: '10.2'
 un_custodian_agency: United Nations Children's Fund (UNICEF) World Bank (WB)
 un_designated_tier: '3'

--- a/meta/10-3-1.md
+++ b/meta/10-3-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 10-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Ensure equal opportunity and reduce inequalities of outcome, including by
-  eliminating discriminatory laws, policies and practices and promoting appropriate
-  legislation, policies and action in this regard
+target_name: global_targets.10-3-title
 target_id: '10.3'
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)

--- a/meta/10-4-1.md
+++ b/meta/10-4-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 10-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Adopt policies, especially fiscal, wage and social protection policies, and
-  progressively achieve greater equality
+target_name: global_targets.10-4-title
 target_id: '10.4'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '2'

--- a/meta/10-5-1.md
+++ b/meta/10-5-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 10-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Improve the regulation and monitoring of global financial markets and institutions
-  and strengthen the implementation of such regulations
+target_name: global_targets.10-5-title
 target_id: '10.5'
 un_custodian_agency: IMF
 un_designated_tier: '3'

--- a/meta/10-6-1.md
+++ b/meta/10-6-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 10-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Ensure enhanced representation and voice for developing countries in decision-making
-  in global international economic and financial institutions in order to deliver
-  more effective, credible, accountable and legitimate institutions
+target_name: global_targets.10-6-title
 target_id: '10.6'
 un_custodian_agency: United Nations Department of Economic and Social Affairs (DESA)
   / Financing for Development Office (FFDO)

--- a/meta/10-7-1.md
+++ b/meta/10-7-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 10-07-01
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Facilitate orderly, safe, regular and responsible migration and mobility of
-  people, including through the implementation of planned and well-managed migration
-  policies
+target_name: global_targets.10-7-title
 target_id: '10.7'
 un_custodian_agency: ILO,World Bank
 un_designated_tier: '3'

--- a/meta/10-7-2.md
+++ b/meta/10-7-2.md
@@ -10,9 +10,7 @@ indicator_sort_order: 10-07-02
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Facilitate orderly, safe, regular and responsible migration and mobility of
-  people, including through the implementation of planned and well-managed migration
-  policies
+target_name: global_targets.10-7-title
 target_id: '10.7'
 un_custodian_agency: DESA Population Division,IOM
 un_designated_tier: '3'

--- a/meta/10-a-1.md
+++ b/meta/10-a-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 10-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Implement the principle of special and differential treatment for developing
-  countries, in particular least developed countries, in accordance with World Trade
-  Organization agreements
+target_name: global_targets.10-a-title
 target_id: 10.a
 un_custodian_agency: ITC,UNCTAD,WTO
 un_designated_tier: '1'

--- a/meta/10-b-1.md
+++ b/meta/10-b-1.md
@@ -14,10 +14,7 @@ indicator_sort_order: 10-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Encourage official development assistance and financial flows, including foreign
-  direct investment, to States where the need is greatest, in particular least developed
-  countries, African countries, small island developing States and landlocked developing
-  countries, in accordance with their national plans and programmes
+target_name: global_targets.10-b-title
 target_id: 10.b
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: 1 (ODA) / 2 (FDI)

--- a/meta/10-c-1.md
+++ b/meta/10-c-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 10-cc-01
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: By 2030, reduce to less than 3 per cent the transaction costs of migrant remittances
-  and eliminate remittance corridors with costs higher than 5 per cent
+target_name: global_targets.10-c-title
 target_id: 10.c
 un_custodian_agency: World Bank
 un_designated_tier: '2'

--- a/meta/11-1-1.md
+++ b/meta/11-1-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 11-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, ensure access for all to adequate, safe and affordable housing and
-  basic services and upgrade slums
+target_name: global_targets.11-1-title
 target_id: '11.1'
 un_custodian_agency: United Nations Human Settlements Programme (UN-Habitat)
 un_designated_tier: '1'

--- a/meta/11-2-1.md
+++ b/meta/11-2-1.md
@@ -10,10 +10,7 @@ indicator_sort_order: 11-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, provide access to safe, affordable, accessible and sustainable transport
-  systems for all, improving road safety, notably by expanding public transport, with
-  special attention to the needs of those in vulnerable situations, women, children,
-  persons with disabilities and older persons
+target_name: global_targets.11-2-title
 target_id: '11.2'
 un_custodian_agency: UN-Habitat
 un_designated_tier: '2'

--- a/meta/11-3-1.md
+++ b/meta/11-3-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 11-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, enhance inclusive and sustainable urbanization and capacity for participatory,
-  integrated and sustainable human settlement planning and management in all countries
+target_name: global_targets.11-3-title
 target_id: '11.3'
 un_custodian_agency: UN-Habitat
 un_designated_tier: '2'

--- a/meta/11-3-2.md
+++ b/meta/11-3-2.md
@@ -10,8 +10,7 @@ indicator_sort_order: 11-03-02
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, enhance inclusive and sustainable urbanization and capacity for participatory,
-  integrated and sustainable human settlement planning and management in all countries
+target_name: global_targets.11-3-title
 target_id: '11.3'
 un_custodian_agency: UN-Habitat
 un_designated_tier: '3'

--- a/meta/11-4-1.md
+++ b/meta/11-4-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 11-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: Strengthen efforts to protect and safeguard the world’s cultural and natural
-  heritage
+target_name: global_targets.11-4-title
 target_id: '11.4'
 un_custodian_agency: United Nations Educational Scientific and Cultural Organization
   (UNESCO)

--- a/meta/11-5-1.md
+++ b/meta/11-5-1.md
@@ -11,10 +11,7 @@ indicator_sort_order: 11-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, significantly reduce the number of deaths and the number of people
-  affected and substantially decrease the direct economic losses relative to global
-  gross domestic product caused by disasters, including water-related disasters, with
-  a focus on protecting the poor and people in vulnerable situations
+target_name: global_targets.11-5-title
 target_id: '11.5'
 un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
 un_designated_tier: '2'

--- a/meta/11-5-2.md
+++ b/meta/11-5-2.md
@@ -10,10 +10,7 @@ indicator_sort_order: 11-05-02
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, significantly reduce the number of deaths and the number of people
-  affected and substantially decrease the direct economic losses relative to global
-  gross domestic product caused by disasters, including water-related disasters, with
-  a focus on protecting the poor and people in vulnerable situations
+target_name: global_targets.11-5-title
 target_id: '11.5'
 un_custodian_agency: UNISDR
 un_designated_tier: '1'

--- a/meta/11-6-1.md
+++ b/meta/11-6-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 11-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, reduce the adverse per capita environmental impact of cities, including
-  by paying special attention to air quality and municipal and other waste management
+target_name: global_targets.11-6-title
 target_id: '11.6'
 un_custodian_agency: UN-Habitat,UNSD
 un_designated_tier: '2'

--- a/meta/11-6-2.md
+++ b/meta/11-6-2.md
@@ -11,8 +11,7 @@ indicator_sort_order: 11-06-02
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, reduce the adverse per capita environmental impact of cities, including
-  by paying special attention to air quality and municipal and other waste management.
+target_name: global_targets.11-6-title
 target_id: '11.6'
 un_custodian_agency: World Health Organization (WHO)
 un_designated_tier: '1'

--- a/meta/11-7-1.md
+++ b/meta/11-7-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 11-07-01
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, provide universal access to safe, inclusive and accessible, green
-  and public spaces, in particular for women and children, older persons and persons
+target_name: global_targets.11-7-title
   with disabilities
 target_id: '11.7'
 un_custodian_agency: United Nations Human Settlements Programme (UN-Habitat)

--- a/meta/11-7-2.md
+++ b/meta/11-7-2.md
@@ -13,9 +13,7 @@ indicator_sort_order: 11-07-02
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, provide universal access to safe, inclusive and accessible, green
-  and public spaces, in particular for women and children, older persons and persons
-  with disabilities
+target_name: global_targets.11-7-title
 target_id: '11.7'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '3'

--- a/meta/11-a-1.md
+++ b/meta/11-a-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 11-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: Support positive economic, social and environmental links between urban, peri-urban
-  and rural areas by strengthening national and regional development planning
+target_name: global_targets.11-a-title
 target_id: 11.a
 un_custodian_agency: UN-Habitat
 un_designated_tier: '3'

--- a/meta/11-b-1.md
+++ b/meta/11-b-1.md
@@ -10,11 +10,7 @@ indicator_sort_order: 11-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2020, substantially increase the number of cities and human settlements
-  adopting and implementing integrated policies and plans towards inclusion, resource
-  efficiency, mitigation and adaptation to climate change, resilience to disasters,
-  and develop and implement, in line with the Sendai Framework for Disaster Risk Reduction
-  2015-2030, holistic disaster risk management at all levels
+target_name: global_targets.11-b-title
 target_id: 11.b
 un_custodian_agency: UNISDR
 un_designated_tier: '2'

--- a/meta/11-b-2.md
+++ b/meta/11-b-2.md
@@ -10,11 +10,7 @@ indicator_sort_order: 11-bb-02
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2020, substantially increase the number of cities and human settlements
-  adopting and implementing integrated policies and plans towards inclusion, resource
-  efficiency, mitigation and adaptation to climate change, resilience to disasters,
-  and develop and implement, in line with the Sendai Framework for Disaster Risk Reduction
-  2015-2030, holistic disaster risk management at all levels
+target_name: global_targets.11-b-title
 target_id: 11.b
 un_custodian_agency: UNISDR
 un_designated_tier: '3'

--- a/meta/11-c-1.md
+++ b/meta/11-c-1.md
@@ -14,8 +14,7 @@ indicator_sort_order: 11-cc-01
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: Support least developed countries, including through financial and technical
-  assistance, in building sustainable and resilient buildings utilizing local materials
+target_name: global_targets.11-c-title
 target_id: 11.c
 un_custodian_agency:  Organisation for Economic Co-operation and Development (OECD)
   United Nations Environment (UNEP) World Bank (WB)

--- a/meta/12-1-1.md
+++ b/meta/12-1-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 12-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: Implement the 10-Year Framework of Programmes on Sustainable Consumption and
-  Production Patterns, all countries taking action, with developed countries taking
-  the lead, taking into account the development and capabilities of developing countries
+target_name: global_targets.12-1-title
 target_id: '12.1'
 un_custodian_agency: UNEP
 un_designated_tier: '2'

--- a/meta/12-2-1.md
+++ b/meta/12-2-1.md
@@ -11,7 +11,7 @@ indicator_sort_order: 12-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2030, achieve the sustainable management and efficient use of natural resources
+target_name: global_targets.12-2-title
 target_id: '12.2'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '3'

--- a/meta/12-2-2.md
+++ b/meta/12-2-2.md
@@ -11,7 +11,7 @@ indicator_sort_order: 12-02-02
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2030, achieve the sustainable management and efficient use of natural resources
+target_name: global_targets.12-2-title
 target_id: '12.2'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '2'

--- a/meta/12-3-1.md
+++ b/meta/12-3-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 12-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2030, halve per capita global food waste at the retail and consumer levels
-  and reduce food losses along production and supply chains, including post-harvest
-  losses
+target_name: global_targets.12-3-title
 target_id: '12.3'
 un_custodian_agency: FAO, UNEP
 un_designated_tier: '3'

--- a/meta/12-4-1.md
+++ b/meta/12-4-1.md
@@ -10,10 +10,7 @@ indicator_sort_order: 12-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2020, achieve the environmentally sound management of chemicals and all
-  wastes throughout their life cycle, in accordance with agreed international frameworks,
-  and significantly reduce their release to air, water and soil in order to minimize
-  their adverse impacts on human health and the environment
+target_name: global_targets.12-4-title
 target_id: '12.4'
 un_custodian_agency: UNEP
 un_designated_tier: '1'

--- a/meta/12-4-2.md
+++ b/meta/12-4-2.md
@@ -10,10 +10,7 @@ indicator_sort_order: 12-04-02
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2020, achieve the environmentally sound management of chemicals and all
-  wastes throughout their life cycle, in accordance with agreed international frameworks,
-  and significantly reduce their release to air, water and soil in order to minimize
-  their adverse impacts on human health and the environment
+target_name: global_targets.12-4-title
 target_id: '12.4'
 un_custodian_agency: UNSD, UNEP
 un_designated_tier: '3'

--- a/meta/12-5-1.md
+++ b/meta/12-5-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 12-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2030, substantially reduce waste generation through prevention, reduction,
-  recycling and reuse
+target_name: global_targets.12-5-title
 target_id: '12.5'
 un_custodian_agency: United Nations Statistics Division (UNSD), UN Environment (UNEP)
 un_designated_tier: '3'

--- a/meta/12-6-1.md
+++ b/meta/12-6-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 12-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: Encourage companies, especially large and transnational companies, to adopt
-  sustainable practices and to integrate sustainability information into their reporting
-  cycle
+target_name: global_targets.12-6-title
 target_id: '12.6'
 un_custodian_agency: UNEP,  UNCTAD
 un_designated_tier: '3'

--- a/meta/12-7-1.md
+++ b/meta/12-7-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 12-07-01
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: Promote public procurement practices that are sustainable, in accordance with
-  national policies and priorities
+target_name: global_targets.12-7-title
 target_id: '12.7'
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/12-8-1.md
+++ b/meta/12-8-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 12-08-01
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2030, ensure that people everywhere have the relevant information and awareness
-  for sustainable development and lifestyles in harmony with nature
+target_name: global_targets.12-8-title
 target_id: '12.8'
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '3'

--- a/meta/12-a-1.md
+++ b/meta/12-a-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 12-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: Support developing countries to strengthen their scientific and technological
-  capacity to move towards more sustainable patterns of consumption and production
+target_name: global_targets.12-a-title
 target_id: 12.a
 un_custodian_agency: Under discussion among agencies (OECD, UNEP,UNESCO-UIS,World
   Bank)

--- a/meta/12-b-1.md
+++ b/meta/12-b-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 12-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: Develop and implement tools to monitor sustainable development impacts for
-  sustainable tourism that creates jobs and promotes local culture and products
+target_name: global_targets.12-b-title
 target_id: 12.b
 un_custodian_agency: UNWTO
 un_designated_tier: '3'

--- a/meta/12-c-1.md
+++ b/meta/12-c-1.md
@@ -10,12 +10,7 @@ indicator_sort_order: 12-cc-01
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: Rationalize inefficient fossil-fuel subsidies that encourage wasteful consumption
-  by removing market distortions, in accordance with national circumstances, including
-  by restructuring taxation and phasing out those harmful subsidies, where they exist,
-  to reflect their environmental impacts, taking fully into account the specific needs
-  and conditions of developing countries and minimizing the possible adverse impacts
-  on their development in a manner that protects the poor and the affected communities
+target_name: global_targets.12-c-title
 target_id: 12.c
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/13-1-1.md
+++ b/meta/13-1-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 13-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Strengthen resilience and adaptive capacity to climate-related hazards and
-  natural disasters in all countries
+target_name: global_targets.13-1-title
 target_id: '13.1'
 un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
 un_designated_tier: '2'

--- a/meta/13-1-2.md
+++ b/meta/13-1-2.md
@@ -10,8 +10,7 @@ indicator_sort_order: 13-01-02
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Strengthen resilience and adaptive capacity to climate-related hazards and
-  natural disasters in all countries
+target_name: global_targets.13-1-title
 target_id: '13.1'
 un_custodian_agency: UNISDR
 un_designated_tier: '2'

--- a/meta/13-1-3.md
+++ b/meta/13-1-3.md
@@ -9,8 +9,7 @@ indicator_sort_order: 13-01-03
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Strengthen resilience and adaptive capacity to climate-related hazards and
-  natural disasters in all countries
+target_name: global_targets.13-1-title
 target_id: '13.1'
 un_custodian_agency: UNISDR
 un_designated_tier: '3'

--- a/meta/13-2-1.md
+++ b/meta/13-2-1.md
@@ -10,7 +10,7 @@ indicator_sort_order: 13-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Integrate climate change measures into national policies, strategies and planning
+target_name: global_targets.13-2-title
 target_id: '13.2'
 un_custodian_agency: UNFCCC
 un_designated_tier: '3'

--- a/meta/13-3-1.md
+++ b/meta/13-3-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 13-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Improve education, awareness-raising and human and institutional capacity
-  on climate change mitigation, adaptation, impact reduction and early warning
+target_name: global_targets.13-3-title
 target_id: '13.3'
 un_custodian_agency: UNFCCC,UNESCO-UIS
 un_designated_tier: '3'

--- a/meta/13-3-2.md
+++ b/meta/13-3-2.md
@@ -10,8 +10,7 @@ indicator_sort_order: 13-03-02
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Improve education, awareness-raising and human and institutional capacity
-  on climate change mitigation, adaptation, impact reduction and early warning
+target_name: global_targets.13-3-title
 target_id: '13.3'
 un_custodian_agency: UNFCCC,UNESCO-UIS
 un_designated_tier: '3'

--- a/meta/13-a-1.md
+++ b/meta/13-a-1.md
@@ -10,12 +10,7 @@ indicator_sort_order: 13-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Implement the commitment undertaken by developed-country parties to the United
-  Nations Framework Convention on Climate Change to a goal of mobilizing jointly $100
-  billion annually by 2020 from all sources to address the needs of developing countries
-  in the context of meaningful mitigation actions and transparency on implementation
-  and fully operationalize the Green Climate Fund through its capitalization as soon
-  as possible
+target_name: global_targets.13-a-title
 target_id: 13.a
 un_custodian_agency: UNFCCC,OECD
 un_designated_tier: '3'

--- a/meta/13-b-1.md
+++ b/meta/13-b-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 13-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Promote mechanisms for raising capacity for effective climate change-related
-  planning and management in least developed countries and small island developing
-  States, including focusing on women, youth and local and marginalized communities
+target_name: global_targets.13-b-title
 target_id: 13.b
 un_custodian_agency: OHRLLS, Regional Commissions, AOSIS, SIDS, Samoa Pathway
 un_designated_tier: '3'

--- a/meta/14-1-1.md
+++ b/meta/14-1-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 14-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2025, prevent and significantly reduce marine pollution of all kinds, in
-  particular from land-based activities, including marine debris and nutrient pollution
+target_name: global_targets.14-1-title
 target_id: '14.1'
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/14-2-1.md
+++ b/meta/14-2-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 14-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2020, sustainably manage and protect marine and coastal ecosystems to avoid
-  significant adverse impacts, including by strengthening their resilience, and take
-  action for their restoration in order to achieve healthy and productive oceans
+target_name: global_targets.14-2-title
 target_id: '14.2'
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/14-3-1.md
+++ b/meta/14-3-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 14-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: Minimize and address the impacts of ocean acidification, including through
-  enhanced scientific cooperation at all levels
+target_name: global_targets.14-3-title
 target_id: '14.3'
 un_custodian_agency: 'IOC-UNESCO '
 un_designated_tier: '3'

--- a/meta/14-4-1.md
+++ b/meta/14-4-1.md
@@ -17,11 +17,7 @@ indicator_sort_order: 14-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2020, effectively regulate harvesting and end overfishing, illegal, unreported
-  and unregulated fishing and destructive fishing practices and implement science-based
-  management plans, in order to restore fish stocks in the shortest time feasible,
-  at least to levels that can produce maximum sustainable yield as determined by their
-  biological characteristics
+target_name: global_targets.14-4-title
 target_id: '14.4'
 un_custodian_agency: Food and Agriculture Organization of the United Nations (FAO)
 un_designated_tier: '1'

--- a/meta/14-5-1.md
+++ b/meta/14-5-1.md
@@ -15,8 +15,7 @@ indicator_sort_order: 14-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2020, conserve at least 10 per cent of coastal and marine areas, consistent
-  with national and international law and based on the best available scientific information
+target_name: global_targets.14-5-title
 target_id: '14.5'
 un_custodian_agency: UN Environment World Conservation Monitoring Centre (UNEP-WCMC)
   BirdLife International (BLI) International Union for Conservation of Nature (IUCN)

--- a/meta/14-6-1.md
+++ b/meta/14-6-1.md
@@ -10,12 +10,7 @@ indicator_sort_order: 14-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2020, prohibit certain forms of fisheries subsidies which contribute to
-  overcapacity and overfishing, eliminate subsidies that contribute to illegal, unreported
-  and unregulated fishing and refrain from introducing new such subsidies, recognizing
-  that appropriate and effective special and differential treatment for developing
-  and least developed countries should be an integral part of the World Trade Organization
-  fisheries subsidies negotiationb
+target_name: global_targets.14-6-title
 target_id: '14.6'
 un_custodian_agency: FAO
 un_designated_tier: '3'

--- a/meta/14-7-1.md
+++ b/meta/14-7-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 14-07-01
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2030, increase the economic benefits to small island developing States
-  and least developed countries from the sustainable use of marine resources, including
-  through sustainable management of fisheries, aquaculture and tourism
+target_name: global_targets.14-7-title
 target_id: '14.7'
 un_custodian_agency: FAO,UNEP-WCMC
 un_designated_tier: '3'

--- a/meta/14-a-1.md
+++ b/meta/14-a-1.md
@@ -10,11 +10,7 @@ indicator_sort_order: 14-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: Increase scientific knowledge, develop research capacity and transfer marine
-  technology, taking into account the Intergovernmental Oceanographic Commission Criteria
-  and Guidelines on the Transfer of Marine Technology, in order to improve ocean health
-  and to enhance the contribution of marine biodiversity to the development of developing
-  countries, in particular small island developing States and least developed countries
+target_name: global_targets.14-a-title
 target_id: 14.a
 un_custodian_agency: IOC-UNESCO
 un_designated_tier: '2'

--- a/meta/14-b-1.md
+++ b/meta/14-b-1.md
@@ -10,7 +10,7 @@ indicator_sort_order: 14-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: Provide access for small-scale artisanal fishers to marine resources and markets
+target_name: global_targets.14-b-title
 target_id: 14.b
 un_custodian_agency: FAO
 un_designated_tier: '3'

--- a/meta/14-c-1.md
+++ b/meta/14-c-1.md
@@ -10,11 +10,7 @@ indicator_sort_order: 14-cc-01
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: Enhance the conservation and sustainable use of oceans and their resources
-  by implementing international law as reflected in the United Nations Convention
-  on the Law of the Sea, which provides the legal framework for the conservation and
-  sustainable use of oceans and their resources, as recalled in paragraph 158 of “The
-  future we want”
+target_name: global_targets.14-c-title
 target_id: 14.c
 un_custodian_agency: UN-DOALOS,FAO,UNEP,ILO,other UN-Oceans agencies
 un_designated_tier: '3'

--- a/meta/15-1-1.md
+++ b/meta/15-1-1.md
@@ -12,10 +12,8 @@ indicator_sort_order: 15-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Protect, restore and promote sustainable use of terrestrial ecosystems, sustainably
-  manage forests, combat desertification, and halt and reverse land degradation and
-  halt biodiversity loss
-target_id: '15'
+target_name: global_targets.15-1-title
+target_id: '15-1'
 un_custodian_agency: Food and Agricultural Organization
 un_designated_tier: '1'
 ---

--- a/meta/15-1-2.md
+++ b/meta/15-1-2.md
@@ -10,9 +10,7 @@ indicator_sort_order: 15-01-02
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2020, ensure the conservation, restoration and sustainable use of terrestrial
-  and inland freshwater ecosystems and their services, in particular forests, wetlands,
-  mountains and drylands, in line with obligations under international agreements
+target_name: global_targets.15-1-title
 target_id: '15.1'
 un_custodian_agency: UNEP-WCMC,UNEP
 un_designated_tier: '1'

--- a/meta/15-2-1.md
+++ b/meta/15-2-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 15-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2020, promote the implementation of sustainable management of all types
-  of forests, halt deforestation, restore degraded forests and substantially increase
-  afforestation and reforestation globally
+target_name: global_targets.15-2-title
 target_id: '15.2'
 un_custodian_agency: Food and Agriculture Organisation of the United Nations (FAO)
 un_designated_tier: '1'

--- a/meta/15-3-1.md
+++ b/meta/15-3-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 15-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2030, combat desertification, restore degraded land and soil, including
-  land affected by desertification, drought and floods, and strive to achieve a land
-  degradation-neutral world
+target_name: global_targets.15-3-title
 target_id: '15.3'
 un_custodian_agency: UNCCD
 un_designated_tier: '3'

--- a/meta/15-4-1.md
+++ b/meta/15-4-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 15-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2030, ensure the conservation of mountain ecosystems, including their biodiversity,
-  in order to enhance their capacity to provide benefits that are essential for sustainable
-  development
+target_name: global_targets.15-4-title
 target_id: '15.4'
 un_custodian_agency: UNEP-WCMC,UNEP
 un_designated_tier: '1'

--- a/meta/15-4-2.md
+++ b/meta/15-4-2.md
@@ -11,9 +11,7 @@ indicator_sort_order: 15-04-02
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2030, ensure the conservation of mountain ecosystems, including their biodiversity,
-  in order to enhance their capacity to provide benefits that are essential for sustainable
-  development
+target_name: global_targets.15-4-title
 target_id: '15.4'
 un_custodian_agency: Food and Agriculture Organization (FAO)
 un_designated_tier: '1'

--- a/meta/15-5-1.md
+++ b/meta/15-5-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 15-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Take urgent and significant action to reduce the degradation of natural habitats,
-  halt the loss of biodiversity and, by 2020, protect and prevent the extinction of
-  threatened species
+target_name: global_targets.15-5-title
 target_id: '15.5'
 un_custodian_agency: International Union for Conservation of Nature (IUCN) BirdLife
   International (BLI)

--- a/meta/15-6-1.md
+++ b/meta/15-6-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 15-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Promote fair and equitable sharing of the benefits arising from the utilization
-  of genetic resources and promote appropriate access to such resources, as internationally
-  agreed
+target_name: global_targets.15-6-title
 target_id: '15.6'
 un_custodian_agency: CBD-Secretariat
 un_designated_tier: '1'

--- a/meta/15-7-1.md
+++ b/meta/15-7-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 15-07-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Take urgent action to end poaching and trafficking of protected species of
-  flora and fauna and address both demand and supply of illegal wildlife products
+target_name: global_targets.15-7-title
 target_id: '15.7'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '2'

--- a/meta/15-8-1.md
+++ b/meta/15-8-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 15-08-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2020, introduce measures to prevent the introduction and significantly
-  reduce the impact of invasive alien species on land and water ecosystems and control
-  or eradicate the priority species
+target_name: global_targets.15-8-title
 target_id: '15.8'
 un_custodian_agency: IUCN
 un_designated_tier: '2'

--- a/meta/15-9-1.md
+++ b/meta/15-9-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 15-09-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2020, integrate ecosystem and biodiversity values into national and local
-  planning, development processes, poverty reduction strategies and accounts
+target_name: global_targets.15-9-title
 target_id: '15.9'
 un_custodian_agency: CBD-Secretariat,UNEP
 un_designated_tier: '3'

--- a/meta/15-a-1.md
+++ b/meta/15-a-1.md
@@ -13,8 +13,7 @@ indicator_sort_order: 15-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Mobilize and significantly increase financial resources from all sources to
-  conserve and sustainably use biodiversity and ecosystems
+target_name: global_targets.15-a-title
 target_id: 15.a
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: 1/3

--- a/meta/15-b-1.md
+++ b/meta/15-b-1.md
@@ -13,9 +13,7 @@ indicator_sort_order: 15-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Mobilize significant resources from all sources and at all levels to finance
-  sustainable forest management and provide adequate incentives to developing countries
-  to advance such management, including for conservation and reforestation
+target_name: global_targets.15-b-title
 target_id: 15.b
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: 1/3

--- a/meta/15-c-1.md
+++ b/meta/15-c-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 15-cc-01
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Enhance global support for efforts to combat poaching and trafficking of protected
-  species, including by increasing the capacity of local communities to pursue sustainable
-  livelihood opportunities
+target_name: global_targets.15-c-title
 target_id: 15.c
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '2'

--- a/meta/16-1-1.md
+++ b/meta/16-1-1.md
@@ -11,7 +11,7 @@ indicator_sort_order: 16-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Significantly reduce all forms of violence and related death rates everywhere
+target_name: global_targets.16-1-title
 target_id: '16.1'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC) World Health
   Organization (WHO)

--- a/meta/16-1-2.md
+++ b/meta/16-1-2.md
@@ -11,7 +11,7 @@ indicator_sort_order: 16-01-02
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Significantly reduce all forms of violence and related death rates everywhere
+target_name: global_targets.16-1-title
 target_id: '16.1'
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)

--- a/meta/16-1-3.md
+++ b/meta/16-1-3.md
@@ -11,7 +11,7 @@ indicator_sort_order: 16-01-03
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: 16.1 Significantly reduce all forms of violence and related death rates everywhere
+target_name: global_targets.16-1-title
 target_id: '16.1'
 un_custodian_agency: UNODC
 un_designated_tier: '2'

--- a/meta/16-1-4.md
+++ b/meta/16-1-4.md
@@ -11,7 +11,7 @@ indicator_sort_order: 16-01-04
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: 16.1 Significantly reduce all forms of violence and related death rates everywhere
+target_name: global_targets.16-1-title
 target_id: '16.1'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: 2

--- a/meta/16-10-1.md
+++ b/meta/16-10-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 16-10-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Ensure public access to information and protect fundamental freedoms, in accordance
-  with national legislation and international agreements
+target_name: global_targets.16-10-title
 target_id: '16.10'
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)

--- a/meta/16-10-2.md
+++ b/meta/16-10-2.md
@@ -10,8 +10,7 @@ indicator_sort_order: 16-10-02
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Ensure public access to information and protect fundamental freedoms, in accordance
-  with national legislation and international agreements
+target_name: global_targets.16-10-title
 target_id: '16.10'
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '2'

--- a/meta/16-2-1.md
+++ b/meta/16-2-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 16-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: End abuse, exploitation, trafficking and all forms of violence against and
-  torture of children
+target_name: global_targets.16-2-title
 target_id: '16.2'
 un_custodian_agency: UNICEF
 un_designated_tier: '2'

--- a/meta/16-2-2.md
+++ b/meta/16-2-2.md
@@ -10,8 +10,7 @@ indicator_sort_order: 16-02-02
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: End abuse, exploitation, trafficking and all forms of violence against and
-  torture of children
+target_name: global_targets.16-2-title
 target_id: '16.2'
 un_custodian_agency: UNODC
 un_designated_tier: '2'

--- a/meta/16-2-3.md
+++ b/meta/16-2-3.md
@@ -16,8 +16,7 @@ indicator_sort_order: 16-02-03
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: End abuse, exploitation, trafficking and all forms of violence against and
-  torture of children
+target_name: global_targets.16-2-title
 target_id: '16.2'
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '2'

--- a/meta/16-3-1.md
+++ b/meta/16-3-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 16-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Promote the rule of law at the national and international levels and ensure
-  equal access to justice for all
+target_name: global_targets.16-3-title
 target_id: '16.3'
 un_custodian_agency: UNODC
 un_designated_tier: '2'

--- a/meta/16-3-2.md
+++ b/meta/16-3-2.md
@@ -11,8 +11,7 @@ indicator_sort_order: 16-03-02
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Promote the rule of law at the national and international levels and ensure
-  equal access to justice for all
+target_name: global_targets.16-3-title
 target_id: '16.3'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '1'

--- a/meta/16-4-1.md
+++ b/meta/16-4-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 16-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: By 2030, significantly reduce illicit financial and arms flows, strengthen
-  the recovery and return of stolen assets and combat all forms of organized crime
+target_name: global_targets.16-4-title
 target_id: '16.4'
 un_custodian_agency: UNODC,UNCTAD
 un_designated_tier: '3'

--- a/meta/16-4-2.md
+++ b/meta/16-4-2.md
@@ -10,8 +10,7 @@ indicator_sort_order: 16-04-02
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: By 2030, significantly reduce illicit financial and arms flows, strengthen
-  the recovery and return of stolen assets and combat all forms of organized crime
+target_name: global_targets.16-4-title
 target_id: '16.4'
 un_custodian_agency: UNODC,UNODA
 un_designated_tier: '3'

--- a/meta/16-5-1.md
+++ b/meta/16-5-1.md
@@ -10,7 +10,7 @@ indicator_sort_order: 16-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Substantially reduce corruption and bribery in all their forms
+target_name: global_targets.16-5-title
 target_id: '16.5'
 un_custodian_agency: UNODC
 un_designated_tier: '2'

--- a/meta/16-5-2.md
+++ b/meta/16-5-2.md
@@ -10,7 +10,7 @@ indicator_sort_order: 16-05-02
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Substantially reduce corruption and bribery in all their forms
+target_name: global_targets.16-5-title
 target_id: '16.5'
 un_custodian_agency: World Bank,UNODC
 un_designated_tier: '2'

--- a/meta/16-6-1.md
+++ b/meta/16-6-1.md
@@ -10,7 +10,7 @@ indicator_sort_order: 16-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Develop effective, accountable and transparent institutions at all levels
+target_name: global_targets.16-6-title
 target_id: '16.6'
 un_custodian_agency: World Bank
 un_designated_tier: '1'

--- a/meta/16-6-2.md
+++ b/meta/16-6-2.md
@@ -10,7 +10,7 @@ indicator_sort_order: 16-06-02
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Develop effective, accountable and transparent institutions at all levels
+target_name: global_targets.16-6-title
 target_id: '16.6'
 un_custodian_agency: UNDP
 un_designated_tier: '3'

--- a/meta/16-7-1.md
+++ b/meta/16-7-1.md
@@ -14,8 +14,7 @@ indicator_sort_order: 16-07-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Ensure responsive, inclusive, participatory and representative decision-making
-  at all levels
+target_name: global_targets.16-7-title
 target_id: '16.7'
 un_custodian_agency: United Nations Development Programme (UNDP)
 un_designated_tier: '3'

--- a/meta/16-7-2.md
+++ b/meta/16-7-2.md
@@ -11,8 +11,7 @@ indicator_sort_order: 16-07-02
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Ensure responsive, inclusive, participatory and representative decision-making
-  at all levels
+target_name: global_targets.16-7-title
 target_id: '16.7'
 un_custodian_agency: United Nations Development Programme (UNDP)
 un_designated_tier: '3'

--- a/meta/16-8-1.md
+++ b/meta/16-8-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 16-08-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Broaden and strengthen the participation of developing countries in the institutions
-  of global governance
+target_name: global_targets.16-8-title
 target_id: '16.8'
 un_custodian_agency: DESA/FFDO
 un_designated_tier: '1'

--- a/meta/16-9-1.md
+++ b/meta/16-9-1.md
@@ -10,7 +10,7 @@ indicator_sort_order: 16-09-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: By 2030, provide legal identity for all, including birth registration
+target_name: global_targets.16-9-title
 target_id: '16.9'
 un_custodian_agency: United Nations Statistics Division (UNSD), United Nations International
   Children's Emergency Fund (UNICEF)

--- a/meta/16-a-1.md
+++ b/meta/16-a-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 16-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Strengthen relevant national institutions, including through international
-  cooperation, for building capacity at all levels, in particular in developing countries,
-  to prevent violence and combat terrorism and crime
+target_name: global_targets.16-a-title
 target_id: 16.a
 un_custodian_agency: OHCHR
 un_designated_tier: '1'

--- a/meta/16-b-1.md
+++ b/meta/16-b-1.md
@@ -11,7 +11,7 @@ indicator_sort_order: 16-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Promote and enforce non-discriminatory laws and policies for sustainable development
+target_name: global_targets.16-b-title
 target_id: 16.b
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)

--- a/meta/17-1-1.md
+++ b/meta/17-1-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 17-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Strengthen domestic resource mobilization, including through international
-  support to developing countries, to improve domestic capacity for tax and other
-  revenue collection
+target_name: global_targets.17-1-title
 target_id: '17.1'
 un_custodian_agency: International Monetary Fund (IMF)
 un_designated_tier: '1'

--- a/meta/17-1-2.md
+++ b/meta/17-1-2.md
@@ -11,9 +11,7 @@ indicator_sort_order: 17-01-02
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Strengthen domestic resource mobilization, including through international
-  support to developing countries, to improve domestic capacity for tax and other
-  revenue collection
+target_name: global_targets.17-1-title
 target_id: '17.1'
 un_custodian_agency: International Monetary Fund (IMF)
 un_designated_tier: '1'

--- a/meta/17-10-1.md
+++ b/meta/17-10-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 17-10-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Promote a universal, rules-based, open, non‑discriminatory and equitable multilateral
-  trading system under the World Trade Organization, including through the conclusion
-  of negotiations under its Doha Development Agenda
+target_name: global_targets.17-10-title
 target_id: '17.10'
 un_custodian_agency: WTO,ITC,UNCTAD
 un_designated_tier: '1'

--- a/meta/17-11-1.md
+++ b/meta/17-11-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 17-11-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Significantly increase the exports of developing countries, in particular
-  with a view to doubling the least developed countries’ share of global exports by
-  2020
+target_name: global_targets.17-11-title
 target_id: '17.11'
 un_custodian_agency: WTO,ITC,UNCTAD
 un_designated_tier: '1'

--- a/meta/17-12-1.md
+++ b/meta/17-12-1.md
@@ -10,11 +10,7 @@ indicator_sort_order: 17-12-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Realize timely implementation of duty-free and quota-free market access on
-  a lasting basis for all least developed countries, consistent with World Trade Organization
-  decisions, including by ensuring that preferential rules of origin applicable to
-  imports from least developed countries are transparent and simple, and contribute
-  to facilitating market access
+target_name: global_targets.17-12-title
 target_id: '17.12'
 un_custodian_agency: WTO,ITC,UNCTAD
 un_designated_tier: '1'

--- a/meta/17-13-1.md
+++ b/meta/17-13-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 17-13-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Enhance global macroeconomic stability, including through policy coordination
-  and policy coherence
+target_name: global_targets.17-13-title
 target_id: '17.13'
 un_custodian_agency: World Bank
 un_designated_tier: '3'

--- a/meta/17-14-1.md
+++ b/meta/17-14-1.md
@@ -10,7 +10,7 @@ indicator_sort_order: 17-14-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Enhance policy coherence for sustainable development
+target_name: global_targets.17-14-title
 target_id: '17.14'
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/17-15-1.md
+++ b/meta/17-15-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 17-15-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Respect each country’s policy space and leadership to establish and implement
-  policies for poverty eradication and sustainable development
+target_name: global_targets.17-15-title
 target_id: '17.15'
 un_custodian_agency: OECD, UNDP
 un_designated_tier: '2'

--- a/meta/17-16-1.md
+++ b/meta/17-16-1.md
@@ -10,10 +10,7 @@ indicator_sort_order: 17-16-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Enhance the Global Partnership for Sustainable Development, complemented by
-  multi-stakeholder partnerships that mobilize and share knowledge, expertise, technology
-  and financial resources, to support the achievement of the Sustainable Development
-  Goals in all countries, in particular developing countries
+target_name: global_targets.17-16-title
 target_id: '17.16'
 un_custodian_agency: OECD, UNDP
 un_designated_tier: '2'

--- a/meta/17-17-1.md
+++ b/meta/17-17-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 17-17-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Encourage and promote effective public, public-private and civil society partnerships,
-  building on the experience and resourcing strategies of partnerships
+target_name: global_targets.17-17-title
 target_id: '17.17'
 un_custodian_agency: World Bank
 un_designated_tier: '3'

--- a/meta/17-18-1.md
+++ b/meta/17-18-1.md
@@ -10,11 +10,7 @@ indicator_sort_order: 17-18-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: By 2020, enhance capacity-building support to developing countries, including
-  for least developed countries and small island developing States, to increase significantly
-  the availability of high-quality, timely and reliable data disaggregated by income,
-  gender, age, race, ethnicity, migratory status, disability, geographic location
-  and other characteristics relevant in national contexts
+target_name: global_targets.17-18-title
 target_id: '17.18'
 un_custodian_agency: UNSD
 un_designated_tier: '3'

--- a/meta/17-18-2.md
+++ b/meta/17-18-2.md
@@ -10,11 +10,7 @@ indicator_sort_order: 17-18-02
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: By 2020, enhance capacity-building support to developing countries, including
-  for least developed countries and small island developing States, to increase significantly
-  the availability of high-quality, timely and reliable data disaggregated by income,
-  gender, age, race, ethnicity, migratory status, disability, geographic location
-  and other characteristics relevant in national contexts
+target_name: global_targets.17-18-title
 target_id: '17.18'
 un_custodian_agency: UNSD,PARIS21, Regional Commissions,World Bank
 un_designated_tier: '2'

--- a/meta/17-18-3.md
+++ b/meta/17-18-3.md
@@ -10,11 +10,7 @@ indicator_sort_order: 17-18-03
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: By 2020, enhance capacity-building support to developing countries, including
-  for least developed countries and small island developing States, to increase significantly
-  the availability of high-quality, timely and reliable data disaggregated by income,
-  gender, age, race, ethnicity, migratory status, disability, geographic location
-  and other characteristics relevant in national contexts
+target_name: global_targets.17-18-title
 target_id: '17.18'
 un_custodian_agency: PARIS21
 un_designated_tier: '1'

--- a/meta/17-19-1.md
+++ b/meta/17-19-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 17-19-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: By 2030, build on existing initiatives to develop measurements of progress
-  on sustainable development that complement gross domestic product, and support statistical
-  capacity-building in developing countries
+target_name: global_targets.17-19-title
 target_id: '17.19'
 un_custodian_agency: PARIS21
 un_designated_tier: '1'

--- a/meta/17-19-2.md
+++ b/meta/17-19-2.md
@@ -10,9 +10,7 @@ indicator_sort_order: 17-19-02
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: By 2030, build on existing initiatives to develop measurements of progress
-  on sustainable development that complement gross domestic product, and support statistical
-  capacity-building in developing countries
+target_name: global_targets.17-19-title
 target_id: '17.19'
 un_custodian_agency: UNSD
 un_designated_tier: '1'

--- a/meta/17-2-1.md
+++ b/meta/17-2-1.md
@@ -10,12 +10,7 @@ indicator_sort_order: 17-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Developed countries to implement fully their official development assistance
-  commitments, including the commitment by many developed countries to achieve the
-  target of 0.7 per cent of gross national income for official development assistance
-  (ODA/GNI) to developing countries and 0.15 to 0.20 per cent of ODA/GNI to least
-  developed countries; ODA providers are encouraged to consider setting a target to
-  provide at least 0.20 per cent of ODA/GNI to least developed countries
+target_name: global_targets.17-2-title
 target_id: '17.2'
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'

--- a/meta/17-3-1.md
+++ b/meta/17-3-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 17-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Mobilize additional financial resources for developing countries from multiple
-  sources
+target_name: global_targets.17-3-title
 target_id: '17.3'
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD),
   United Nations Conference on Trade and Development (UNCTAD)

--- a/meta/17-3-2.md
+++ b/meta/17-3-2.md
@@ -10,8 +10,7 @@ indicator_sort_order: 17-03-02
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Mobilize additional financial resources for developing countries from multiple
-  sources
+target_name: global_targets.17-3-title
 target_id: '17.3'
 un_custodian_agency: World Bank
 un_designated_tier: '1'

--- a/meta/17-4-1.md
+++ b/meta/17-4-1.md
@@ -10,10 +10,7 @@ indicator_sort_order: 17-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Assist developing countries in attaining long-term debt sustainability through
-  coordinated policies aimed at fostering debt financing, debt relief and debt restructuring,
-  as appropriate, and address the external debt of highly indebted poor countries
-  to reduce debt distress
+target_name: global_targets.17-4-title
 target_id: '17.4'
 un_custodian_agency: World Bank
 un_designated_tier: '1'

--- a/meta/17-5-1.md
+++ b/meta/17-5-1.md
@@ -10,7 +10,7 @@ indicator_sort_order: 17-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Adopt and implement investment promotion regimes for least developed countries
+target_name: global_targets.17-5-title
 target_id: '17.5'
 un_custodian_agency: UNCTAD
 un_designated_tier: '3'

--- a/meta/17-6-1.md
+++ b/meta/17-6-1.md
@@ -10,11 +10,7 @@ indicator_sort_order: 17-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Enhance North-South, South-South and triangular regional and international
-  cooperation on and access to science, technology and innovation and enhance knowledge-sharing
-  on mutually agreed terms, including through improved coordination among existing
-  mechanisms, in particular at the United Nations level, and through a global technology
-  facilitation mechanism
+target_name: global_targets.17-6-title
 target_id: '17.6'
 un_custodian_agency: United Nations Education,Scientific and Cultural Organisation
   (UNESCO) - Institute for Statistics (UIS)

--- a/meta/17-6-2.md
+++ b/meta/17-6-2.md
@@ -11,11 +11,7 @@ indicator_sort_order: 17-06-02
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Enhance North-South, South-South and triangular regional and international
-  cooperation on and access to science, technology and innovation and enhance knowledge-sharing
-  on mutually agreed terms, including through improved coordination among existing
-  mechanisms, in particular at the United Nations level, and through a global technology
-  facilitation mechanism
+target_name: global_targets.17-6-title
 target_id: '17.6'
 un_custodian_agency: International Telecommunication Union (ITU)
 un_designated_tier: '1'

--- a/meta/17-7-1.md
+++ b/meta/17-7-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 17-07-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Promote the development, transfer, dissemination and diffusion of environmentally
-  sound technologies to developing countries on favourable terms, including on concessional
-  and preferential terms, as mutually agreed
+target_name: global_targets.17-7-title
 target_id: '17.7'
 un_custodian_agency: UNEP-CTCN
 un_designated_tier: '3'

--- a/meta/17-8-1.md
+++ b/meta/17-8-1.md
@@ -14,9 +14,7 @@ indicator_sort_order: 17-08-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Fully operationalize the technology bank and science, technology and innovation
-  capacity-building mechanism for least developed countries by 2017 and enhance the
-  use of enabling technology, in particular information and communications technology
+target_name: global_targets.17-8-title
 target_id: '17.8'
 un_custodian_agency: International Telecommunications Union (ITU)
 un_designated_tier: '1'

--- a/meta/17-9-1.md
+++ b/meta/17-9-1.md
@@ -14,9 +14,7 @@ indicator_sort_order: 17-09-01
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Enhance international support for implementing effective and targeted capacity-building
-  in developing countries to support national plans to implement all the Sustainable
-  Development Goals, including through North-South, South-South and triangular cooperation
+target_name: global_targets.17-9-title
 target_id: '17.9'
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
   United Nations Environment (UNEP) World Bank (WB)

--- a/meta/2-1-1.md
+++ b/meta/2-1-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 02-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2030, end hunger and ensure access by all people, in particular the poor
-  and people in vulnerable situations, including infants, to safe, nutritious and
-  sufficient food all year round.
+target_name: global_targets.2-1-title
 target_id: '2.1'
 un_custodian_agency: FAO
 un_designated_tier: '1'

--- a/meta/2-1-2.md
+++ b/meta/2-1-2.md
@@ -10,9 +10,7 @@ indicator_sort_order: 02-01-02
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2030, end hunger and ensure access by all people, in particular the poor
-  and people in vulnerable situations, including infants, to safe, nutritious and
-  sufficient food all year round.
+target_name: global_targets.2-1-title
 target_id: '2.1'
 un_custodian_agency: Food and Agriculture Organization (FAO)
 un_designated_tier: '1'

--- a/meta/2-2-1.md
+++ b/meta/2-2-1.md
@@ -10,10 +10,7 @@ indicator_sort_order: 02-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2030, end all forms of malnutrition, including achieving, by 2025, the
-  internationally agreed targets on stunting and wasting in children under 5 years
-  of age, and address the nutritional needs of adolescent girls, pregnant and lactating
-  women and older persons
+target_name: global_targets.2-2-title
 target_id: '2.2'
 un_custodian_agency: UNICEF
 un_designated_tier: '1'

--- a/meta/2-2-2.md
+++ b/meta/2-2-2.md
@@ -10,10 +10,7 @@ indicator_sort_order: 02-02-02
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2030, end all forms of malnutrition, including achieving, by 2025, the
-  internationally agreed targets on stunting and wasting in children under 5 years
-  of age, and address the nutritional needs of adolescent girls, pregnant and lactating
-  women and older persons
+target_name: global_targets.2-2-title
 target_id: '2.2'
 un_custodian_agency: UNICEF
 un_designated_tier: '1'

--- a/meta/2-3-1.md
+++ b/meta/2-3-1.md
@@ -11,11 +11,7 @@ indicator_sort_order: 02-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2030, double the agricultural productivity and incomes of small-scale food
-  producers, in particular women, indigenous peoples, family farmers, pastoralists
-  and fishers, including through secure and equal access to land, other productive
-  resources and inputs, knowledge, financial services, markets and opportunities for
-  value addition and non-farm employment
+target_name: global_targets.2-3-title
 target_id: '2.3'
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '3'

--- a/meta/2-3-2.md
+++ b/meta/2-3-2.md
@@ -11,11 +11,7 @@ indicator_sort_order: 02-03-02
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2030, double the agricultural productivity and incomes of small-scale food
-  producers, in particular women, indigenous peoples, family farmers, pastoralists
-  and fishers, including through secure and equal access to land, other productive
-  resources and inputs, knowledge, financial services, markets and opportunities for
-  value addition and non-farm employment
+target_name: global_targets.2-3-title
 target_id: '2.3'
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '3'

--- a/meta/2-4-1.md
+++ b/meta/2-4-1.md
@@ -10,11 +10,7 @@ indicator_sort_order: 02-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2030, ensure sustainable food production systems and implement resilient
-  agricultural practices that increase productivity and production, that help maintain
-  ecosystems, that strengthen capacity for adaptation to climate change, extreme weather,
-  drought, flooding and other disasters and that progressively improve land and soil
-  quality
+target_name: global_targets.2-4-title
 target_id: '2.4'
 un_custodian_agency: Food and Agriculture Organization (FAO)
 un_designated_tier: '3'

--- a/meta/2-5-1.md
+++ b/meta/2-5-1.md
@@ -11,12 +11,7 @@ indicator_sort_order: 02-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2020, maintain the genetic diversity of seeds, cultivated plants and farmed
-  and domesticated animals and their related wild species, including through soundly
-  managed and diversified seed and plant banks at the national, regional and international
-  levels, and promote access to and fair and equitable sharing of benefits arising
-  from the utilization of genetic resources and associated traditional knowledge,
-  as internationally agreed
+target_name: global_targets.2-5-title
 target_id: '2.5'
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '1'

--- a/meta/2-5-2.md
+++ b/meta/2-5-2.md
@@ -13,12 +13,7 @@ indicator_sort_order: 02-05-02
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2020, maintain the genetic diversity of seeds, cultivated plants and farmed
-  and domesticated animals and their related wild species, including through soundly
-  managed and diversified seed and plant banks at the national, regional and international
-  levels, and promote access to and fair and equitable sharing of benefits arising
-  from the utilization of genetic resources and associated traditional knowledge,
-  as internationally agreed
+target_name: global_targets.2-5-title
 target_id: '2.5'
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '1'

--- a/meta/2-a-1.md
+++ b/meta/2-a-1.md
@@ -16,10 +16,7 @@ indicator_sort_order: 02-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: Increase investment, including through enhanced international cooperation,
-  in rural infrastructure, agricultural research and extension services, technology
-  development and plant and livestock gene banks in order to enhance agricultural
-  productive capacity in developing countries, in particular least developed countries
+target_name: global_targets.2-a-title
 target_id: 2.a
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '2'

--- a/meta/2-a-2.md
+++ b/meta/2-a-2.md
@@ -13,10 +13,7 @@ indicator_sort_order: 02-aa-02
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: Increase investment, including through enhanced international cooperation,
-  in rural infrastructure, agricultural research and extension services, technology
-  development and plant and livestock gene banks in order to enhance agricultural
-  productive capacity in developing countries, in particular least developed countries
+target_name: global_targets.2-a-title
 target_id: 2.a
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'

--- a/meta/2-b-1.md
+++ b/meta/2-b-1.md
@@ -10,10 +10,7 @@ indicator_sort_order: 02-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: Correct and prevent trade restrictions and distortions in world agricultural
-  markets, including through the parallel elimination of all forms of agricultural
-  export subsidies and all export measures with equivalent effect, in accordance with
-  the mandate of the Doha Development Round
+target_name: global_targets.2-b-title
 target_id: 2.b
 un_custodian_agency: WTO
 un_designated_tier: '1'

--- a/meta/2-c-1.md
+++ b/meta/2-c-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 02-cc-01
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: Adopt measures to ensure the proper functioning of food commodity markets
-  and their derivatives and facilitate timely access to market information, including
-  on food reserves, in order to help limit extreme food price volatility
+target_name: global_targets.2-c-title
 target_id: 2.c
 un_custodian_agency: FAO
 un_designated_tier: '2'

--- a/meta/3-1-1.md
+++ b/meta/3-1-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 03-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, reduce the global maternal mortality ratio to less than 70 per 100,000
-  live births
+target_name: global_targets.3-1-title
 target_id: '3.1'
 un_custodian_agency: WHO
 un_designated_tier: '1'

--- a/meta/3-1-2.md
+++ b/meta/3-1-2.md
@@ -12,8 +12,7 @@ indicator_sort_order: 03-01-02
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, reduce the global maternal mortality ratio to less than 70 per 100,000
-  live births
+target_name: global_targets.3-1-title
 target_id: '3.1'
 un_custodian_agency: United Nations Children's Fund (UNICEFF)
 un_designated_tier: '1'

--- a/meta/3-2-1.md
+++ b/meta/3-2-1.md
@@ -17,10 +17,7 @@ indicator_sort_order: 03-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, end preventable deaths of newborns and children under 5 years of
-  age, with all countries aiming to reduce neonatal mortality to at least as low as
-  12 per 1,000 live births and under-5 mortality to at least as low as 25 per 1,000
-  live births
+target_name: global_targets.3-2-title
 target_id: '3.2'
 un_custodian_agency: United Nations Children's Fund (UNICEFF)
 un_designated_tier: '1'

--- a/meta/3-2-2.md
+++ b/meta/3-2-2.md
@@ -17,10 +17,7 @@ indicator_sort_order: 03-02-02
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, end preventable deaths of newborns and children under 5 years of
-  age, with all countries aiming to reduce neonatal mortality to at least as low as
-  12 per 1,000 live births and under-5 mortality to at least as low as 25 per 1,000
-  live births
+target_name: global_targets.3-2-title
 target_id: '3.2'
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '1'

--- a/meta/3-3-1.md
+++ b/meta/3-3-1.md
@@ -13,8 +13,7 @@ indicator_sort_order: 03-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected tropical
-  diseases and combat hepatitis, water-borne diseases and other communicable diseases
+target_name: global_targets.3-3-title
 target_id: '3.3'
 un_custodian_agency: The Joint United Nations Programme on HIV/AIDS (UNAIDS)
 un_designated_tier: '2'

--- a/meta/3-3-2.md
+++ b/meta/3-3-2.md
@@ -11,8 +11,7 @@ indicator_sort_order: 03-03-02
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected tropical
-  diseases and combat hepatitis, water-borne diseases and other communicable diseases
+target_name: global_targets.3-3-title
 target_id: '3.3'
 un_custodian_agency: World Health Organization (WHO)
 un_designated_tier: '1'

--- a/meta/3-3-3.md
+++ b/meta/3-3-3.md
@@ -11,9 +11,7 @@ indicator_sort_order: 03-03-03
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: 3.3 By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected
-  tropical diseases and combat hepatitis, water-borne diseases and other communicable
-  diseases
+target_name: global_targets.3-3-title
 target_id: '3.3'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: 1

--- a/meta/3-3-4.md
+++ b/meta/3-3-4.md
@@ -10,8 +10,7 @@ indicator_sort_order: 03-03-04
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected tropical
-  diseases and combat hepatitis, water-borne diseases and other communicable diseases
+target_name: global_targets.3-3-title
 target_id: '3.3'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '2'

--- a/meta/3-3-5.md
+++ b/meta/3-3-5.md
@@ -10,8 +10,7 @@ indicator_sort_order: 03-03-05
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected tropical
-  diseases and combat hepatitis, water-borne diseases and other communicable diseases
+target_name: global_targets.3-3-title
 target_id: '3.3'
 un_custodian_agency: WHO
 un_designated_tier: '1'

--- a/meta/3-4-1.md
+++ b/meta/3-4-1.md
@@ -17,8 +17,7 @@ indicator_sort_order: 03-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, reduce by one third premature mortality from non-communicable diseases
-  through prevention and treatment and promote mental health and well-being
+target_name: global_targets.3-4-title
 target_id: '3.4'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-4-2.md
+++ b/meta/3-4-2.md
@@ -12,8 +12,7 @@ indicator_sort_order: 03-04-02
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, reduce by one third premature mortality from non-communicable diseases
-  through prevention and treatment and promote mental health and well-being
+target_name: global_targets.3-4-title
 target_id: '3.4'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-5-1.md
+++ b/meta/3-5-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 03-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Strengthen the prevention and treatment of substance abuse, including narcotic
-  drug abuse and harmful use of alcohol
+target_name: global_targets.3-5-title
 target_id: '3.5'
 un_custodian_agency: WHO,UNODC
 un_designated_tier: '3'

--- a/meta/3-5-2.md
+++ b/meta/3-5-2.md
@@ -11,8 +11,7 @@ indicator_sort_order: 03-05-02
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Strengthen the prevention and treatment of substance abuse, including narcotic
-  drug abuse and harmful use of alcohol
+target_name: global_targets.3-5-title
 target_id: '3.5'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-6-1.md
+++ b/meta/3-6-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 03-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2020, halve the number of global deaths and injuries from road traffic
-  accidents
+target_name: global_targets.3-6-title
 target_id: '3.6'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-7-1.md
+++ b/meta/3-7-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 03-07-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, ensure universal access to sexual and reproductive health-care services,
-  including for family planning, information and education, and the integration of
-  reproductive health into national strategies and programmes
+target_name: global_targets.3-7-title
 target_id: '3.7'
 un_custodian_agency: DESA Population Division
 un_designated_tier: '1'

--- a/meta/3-7-2.md
+++ b/meta/3-7-2.md
@@ -13,9 +13,7 @@ indicator_sort_order: 03-07-02
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, ensure universal access to sexual and reproductive health-care services,
-  including for family planning, information and education, and the integration of
-  reproductive health into national strategies and programmes
+target_name: global_targets.3-7-title
 target_id: '3.7'
 un_custodian_agency: Department of Economic and Social Affairs (DESA) Population Division
   United Nations Population Fund (UNFPA )

--- a/meta/3-8-1.md
+++ b/meta/3-8-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 03-08-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Achieve universal health coverage, including financial risk protection, access
-  to quality essential health-care services and access to safe, effective, quality
-  and affordable essential medicines and vaccines for all
+target_name: global_targets.3-8-title
 target_id: '3.8'
 un_custodian_agency: WHO
 un_designated_tier: '3'

--- a/meta/3-8-2.md
+++ b/meta/3-8-2.md
@@ -11,9 +11,7 @@ indicator_sort_order: 03-08-02
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Achieve universal health coverage, including financial risk protection, access
-  to quality essential health-care services and access to safe, effective, quality
-  and affordable essential medicines and vaccines for all
+target_name: global_targets.3-8-title
 target_id: '3.8'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '2'

--- a/meta/3-9-1.md
+++ b/meta/3-9-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 03-09-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, substantially reduce the number of deaths and illnesses from hazardous
-  chemicals and air, water and soil pollution and contamination
+target_name: global_targets.3-9-title
 target_id: '3.9'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-9-2.md
+++ b/meta/3-9-2.md
@@ -16,8 +16,7 @@ indicator_sort_order: 03-09-02
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, substantially reduce the number of deaths and illnesses from hazardous
-  chemicals and air, water and soil pollution and contamination
+target_name: global_targets.3-9-title
 target_id: '3.9'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-9-3.md
+++ b/meta/3-9-3.md
@@ -11,8 +11,7 @@ indicator_sort_order: 03-09-03
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, substantially reduce the number of deaths and illnesses from hazardous
-  chemicals and air, water and soil pollution and contamination
+target_name: global_targets.3-9-title
 target_id: '3.9'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-a-1.md
+++ b/meta/3-a-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 03-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: 3.a Strengthen the implementation of the World Health Organization Framework
-  Convention on Tobacco Control in all countries, as appropriate
+target_name: global_targets.3-a-title
 target_id: 3.a
 un_custodian_agency: World Health Organization (WHO), Framework Convention on Tobacco
   Control (FCTC)

--- a/meta/3-b-1.md
+++ b/meta/3-b-1.md
@@ -11,13 +11,7 @@ indicator_sort_order: 03-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Support the research and development of vaccines and medicines for the communicable
-  and non-communicable diseases that primarily affect developing countries, provide
-  access to affordable essential medicines and vaccines, in accordance with the Doha
-  Declaration on the TRIPS Agreement and Public Health, which affirms the right of
-  developing countries to use to the full the provisions in the Agreement on Trade-Related
-  Aspects of Intellectual Property Rights regarding flexibilities to protect public
-  health, and, in particular, provide access to medicines for all
+target_name: global_targets.3-b-title
 target_id: 3.b
 un_custodian_agency: World Health Organization (WHO)  United Nations International
   Children's Emergency Fund (UNICEF)

--- a/meta/3-b-2.md
+++ b/meta/3-b-2.md
@@ -14,13 +14,7 @@ indicator_sort_order: 03-bb-02
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Support the research and development of vaccines and medicines for the communicable
-  and non-communicable diseases that primarily affect developing countries, provide
-  access to affordable essential medicines and vaccines, in accordance with the Doha
-  Declaration on the TRIPS Agreement and Public Health, which affirms the right of
-  developing countries to use to the full the provisions in the Agreement on Trade-Related
-  Aspects of Intellectual Property Rights regarding flexibilities to protect public
-  health, and, in particular, provide access to medicines for all
+target_name: global_targets.3-b-title
 target_id: 3.b
 un_custodian_agency: Organisation for Economic Co-operation (OECD)
 un_designated_tier: '1'

--- a/meta/3-b-3.md
+++ b/meta/3-b-3.md
@@ -9,13 +9,7 @@ indicator_sort_order: 03-bb-03
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Support the research and development of vaccines and medicines for the communicable
-  and non‑communicable diseases that primarily affect developing countries, provide
-  access to affordable essential medicines and vaccines, in accordance with the Doha
-  Declaration on the TRIPS Agreement and Public Health, which affirms the right of
-  developing countries to use to the full the provisions in the Agreement on Trade-Related
-  Aspects of Intellectual Property Rights regarding flexibilities to protect public
-  health, and, in particular, provide access to medicines for all
+target_name: global_targets.3-b-title
 target_id: 3.b
 un_custodian_agency: WHO
 un_designated_tier: '3'

--- a/meta/3-c-1.md
+++ b/meta/3-c-1.md
@@ -13,9 +13,7 @@ indicator_sort_order: 03-cc-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Substantially increase health financing and the recruitment, development,
-  training and retention of the health workforce in developing countries, especially
-  in least developed countries and small island developing States
+target_name: global_targets.3-c-title
 target_id: 3.c
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-d-1.md
+++ b/meta/3-d-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 03-dd-01
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Strengthen the capacity of all countries, in particular developing countries,
-  for early warning, risk reduction and management of national and global health risks
+target_name: global_targets.3-d-title
 target_id: 3.d
 un_custodian_agency: WHO
 un_designated_tier: '1'

--- a/meta/4-1-1.md
+++ b/meta/4-1-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 04-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, ensure that all girls and boys complete free, equitable and quality
-  primary and secondary education leading to relevant and effective learning outcomes
+target_name: global_targets.4-1-title
 target_id: '4.1'
 un_custodian_agency: UNESCO Institute for Statistics
 un_designated_tier: 3 (a) /2 (b,c)

--- a/meta/4-2-1.md
+++ b/meta/4-2-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 04-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, ensure that all girls and boys have access to quality early childhood
-  development, care and pre-primary education so that they are ready for primary education
+target_name: global_targets.4-2-title
 target_id: '4.2'
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '3'

--- a/meta/4-2-2.md
+++ b/meta/4-2-2.md
@@ -11,8 +11,7 @@ indicator_sort_order: 04-02-02
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, ensure that all girls and boys have access to quality early childhood
-  development, care and pre-primary education so that they are ready for primary education
+target_name: global_targets.4-2-title
 target_id: '4.2'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)

--- a/meta/4-3-1.md
+++ b/meta/4-3-1.md
@@ -14,8 +14,7 @@ indicator_sort_order: 04-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, ensure equal access for all women and men to affordable and quality
-  technical, vocational and tertiary education, including university
+target_name: global_targets.4-3-title
 target_id: '4.3'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)

--- a/meta/4-4-1.md
+++ b/meta/4-4-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 04-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, substantially increase the number of youth and adults who have relevant
-  skills, including technical and vocational skills, for employment, decent jobs and
-  entrepreneurship
+target_name: global_targets.4-4-title
 target_id: '4.4'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)

--- a/meta/4-5-1.md
+++ b/meta/4-5-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 04-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, eliminate gender disparities in education and ensure equal access
-  to all levels of education and vocational training for the vulnerable, including
-  persons with disabilities, indigenous peoples and children in vulnerable situations
+target_name: global_targets.4-5-title
 target_id: '4.5'
 un_custodian_agency: United Nations Educational, Scientific and Cultural Organization
   (UNESCO)

--- a/meta/4-6-1.md
+++ b/meta/4-6-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 04-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, ensure that all youth and a substantial proportion of adults, both
-  men and women, achieve literacy and numeracy
+target_name: global_targets.4-6-title
 target_id: '4.6'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)

--- a/meta/4-7-1.md
+++ b/meta/4-7-1.md
@@ -10,11 +10,7 @@ indicator_sort_order: 04-07-01
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, ensure that all learners acquire the knowledge and skills needed
-  to promote sustainable development, including, among others, through education for
-  sustainable development and sustainable lifestyles, human rights, gender equality,
-  promotion of a culture of peace and non-violence, global citizenship and appreciation
-  of cultural diversity and of culture’s contribution to sustainable development
+target_name: global_targets.4-7-title
 target_id: '4.7'
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '3'

--- a/meta/4-a-1.md
+++ b/meta/4-a-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 04-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: Build and upgrade education facilities that are child, disability and gender
-  sensitive and provide safe, non-violent, inclusive and effective learning environments
-  for all
+target_name: global_targets.4-a-title
 target_id: 4.a
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '2'

--- a/meta/4-b-1.md
+++ b/meta/4-b-1.md
@@ -13,11 +13,7 @@ indicator_sort_order: 04-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2020, substantially expand globally the number of scholarships available
-  to developing countries, in particular least developed countries, small island developing
-  States and African countries, for enrolment in higher education, including vocational
-  training and information and communications technology, technical, engineering and
-  scientific programmes, in developed countries and other developing countries
+target_name: global_targets.4-b-title
 target_id: 4.b
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'

--- a/meta/4-c-1.md
+++ b/meta/4-c-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 04-cc-01
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, substantially increase the supply of qualified teachers, including
-  through international cooperation for teacher training in developing countries,
-  especially least developed countries and small island developing States
+target_name: global_targets.4-c-title
 target_id: 4.c
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)

--- a/meta/5-1-1.md
+++ b/meta/5-1-1.md
@@ -10,7 +10,7 @@ indicator_sort_order: 05-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: End all forms of discrimination against all women and girls everywhere
+target_name: global_targets.5-1-title
 target_id: '5.1'
 un_custodian_agency: UN Women,World Bank,OECD Development Centre
 un_designated_tier: '3'

--- a/meta/5-2-1.md
+++ b/meta/5-2-1.md
@@ -14,8 +14,7 @@ indicator_sort_order: 05-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Eliminate all forms of violence against all women and girls in the public
-  and private spheres, including trafficking and sexual and other types of exploitation
+target_name: global_targets.5-2-title
 target_id: '5.2'
 un_custodian_agency: 'United Nations Children’s Fund (UNICEF) The United Nations Entity
   for Gender Equality and the Empowerment of Women (UN Women) United Nations Population

--- a/meta/5-2-2.md
+++ b/meta/5-2-2.md
@@ -14,8 +14,7 @@ indicator_sort_order: 05-02-02
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Eliminate all forms of violence against all women and girls in the public
-  and private spheres, including trafficking and sexual and other types of exploitation
+target_name: global_targets.5-2-title
 target_id: '5.2'
 un_custodian_agency: 'United Nations Children’s Fund (UNICEF) The United Nations Entity
   for Gender Equality and the Empowerment of Women (UN Women) United Nations Population

--- a/meta/5-3-1.md
+++ b/meta/5-3-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 05-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Eliminate all harmful practices, such as child, early and forced marriage
-  and female genital mutilation
+target_name: global_targets.5-3-title
 target_id: '5.3'
 un_custodian_agency: United Nations Children's Fund (UNICEFF)
 un_designated_tier: '2'

--- a/meta/5-3-2.md
+++ b/meta/5-3-2.md
@@ -11,8 +11,7 @@ indicator_sort_order: 05-03-02
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Eliminate all harmful practices, such as child, early and forced marriage
-  and female genital mutilation
+target_name: global_targets.5-3-title
 target_id: '5.3'
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '2'

--- a/meta/5-4-1.md
+++ b/meta/5-4-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 05-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Recognize and value unpaid care and domestic work through the provision of
-  public services, infrastructure and social protection policies and the promotion
-  of shared responsibility within the household and the family as nationally appropriate
+target_name: global_targets.5-4-title
 target_id: '5.4'
 un_custodian_agency: UN Statistics Division (UNSD)
 un_designated_tier: '2'

--- a/meta/5-5-1.md
+++ b/meta/5-5-1.md
@@ -13,8 +13,7 @@ indicator_sort_order: 05-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Ensure women’s full and effective participation and equal opportunities for
-  leadership at all levels of decision-making in political, economic and public life
+target_name: global_targets.5-5-title
 target_id: '5.5'
 un_custodian_agency: Inter-Parliamentary Union (IPU)
 un_designated_tier: 1/2

--- a/meta/5-5-2.md
+++ b/meta/5-5-2.md
@@ -11,8 +11,7 @@ indicator_sort_order: 05-05-02
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Ensure women’s full and effective participation and equal opportunities for
-  leadership at all levels of decision-making in political, economic and public life
+target_name: global_targets.5-5-title
 target_id: '5.5'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '1'

--- a/meta/5-6-1.md
+++ b/meta/5-6-1.md
@@ -10,10 +10,7 @@ indicator_sort_order: 05-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Ensure universal access to sexual and reproductive health and reproductive
-  rights as agreed in accordance with the Programme of Action of the International
-  Conference on Population and Development and the Beijing Platform for Action and
-  the outcome documents of their review conferences
+target_name: global_targets.5-6-title
 target_id: '5.6'
 un_custodian_agency: UNFPA
 un_designated_tier: '2'

--- a/meta/5-6-2.md
+++ b/meta/5-6-2.md
@@ -10,10 +10,7 @@ indicator_sort_order: 05-06-02
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Ensure universal access to sexual and reproductive health and reproductive
-  rights as agreed in accordance with the Programme of Action of the International
-  Conference on Population and Development and the Beijing Platform for Action and
-  the outcome documents of their review conferences
+target_name: global_targets.5-6-title
 target_id: '5.6'
 un_custodian_agency: UNFPA
 un_designated_tier: '3'

--- a/meta/5-a-1.md
+++ b/meta/5-a-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 05-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Undertake reforms to give women equal rights to economic resources, as well
-  as access to ownership and control over land and other forms of property, financial
-  services, inheritance and natural resources, in accordance with national laws
+target_name: global_targets.5-a-title
 target_id: 5.a
 un_custodian_agency: United Nations Entity for Gender Equality and the Empowerment
   of Women (UN Women) United Nations Statistics Division (UNSD) Food and Agriculture

--- a/meta/5-a-2.md
+++ b/meta/5-a-2.md
@@ -10,9 +10,7 @@ indicator_sort_order: 05-aa-02
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Undertake reforms to give women equal rights to economic resources, as well
-  as access to ownership and control over land and other forms of property, financial
-  services, inheritance and natural resources, in accordance with national laws
+target_name: global_targets.5-a-title
 target_id: 5.a
 un_custodian_agency: FAO,World Bank, UN Women
 un_designated_tier: '2'

--- a/meta/5-b-1.md
+++ b/meta/5-b-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 05-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Enhance the use of enabling technology, in particular information and communications
-  technology, to promote the empowerment of women
+target_name: global_targets.5-b-title
 target_id: 5.b
 un_custodian_agency: International Telecommunication Union (ITU)
 un_designated_tier: '1'

--- a/meta/5-c-1.md
+++ b/meta/5-c-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 05-cc-01
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Adopt and strengthen sound policies and enforceable legislation for the promotion
-  of gender equality and the empowerment of all women and girls at all levels
+target_name: global_targets.5-c-title
 target_id: 5.c
 un_custodian_agency: UN Women,OECD
 un_designated_tier: '2'

--- a/meta/6-1-1.md
+++ b/meta/6-1-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 06-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, achieve universal and equitable access to safe and affordable drinking
-  water for all
+target_name: global_targets.6-1-title
 target_id: '6.1'
 un_custodian_agency: World Health Organisation (WHO), United Nations Children's Emergency
   Fund (UNICEF)

--- a/meta/6-2-1.md
+++ b/meta/6-2-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 06-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, achieve access to adequate and equitable sanitation and hygiene for
-  all and end open defecation, paying special attention to the needs of women and
-  girls and those in vulnerable situations
+target_name: global_targets.6-2-title
 target_id: '6.2'
 un_custodian_agency: World Health Organisation (WHO), United Nations International
   Children's Emergency Fund (UNICEF)

--- a/meta/6-3-1.md
+++ b/meta/6-3-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 06-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, improve water quality by reducing pollution, eliminating dumping
-  and minimizing release of hazardous chemicals and materials, halving the proportion
-  of untreated wastewater and substantially increasing recycling and safe reuse globally
+target_name: global_targets.6-3-title
 target_id: '6.3'
 un_custodian_agency: WHO, UN-Habitat,UNSD
 un_designated_tier: '2'

--- a/meta/6-3-2.md
+++ b/meta/6-3-2.md
@@ -15,9 +15,7 @@ indicator_sort_order: 06-03-02
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, improve water quality by reducing pollution, eliminating dumping
-  and minimizing release of hazardous chemicals and materials, halving the proportion
-  of untreated wastewater and substantially increasing recycling and safe reuse globally
+target_name: global_targets.6-3-title
 target_id: '6.3'
 un_custodian_agency: United Nations Environment Programme (UNEP) (GEMS/Water)
 un_designated_tier: '3'

--- a/meta/6-4-1.md
+++ b/meta/6-4-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 06-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, substantially increase water-use efficiency across all sectors and
-  ensure sustainable withdrawals and supply of freshwater to address water scarcity
-  and substantially reduce the number of people suffering from water scarcity
+target_name: global_targets.6-4-title
 target_id: '6.4'
 un_custodian_agency: FAO
 un_designated_tier: '2'

--- a/meta/6-4-2.md
+++ b/meta/6-4-2.md
@@ -10,9 +10,7 @@ indicator_sort_order: 06-04-02
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, substantially increase water-use efficiency across all sectors and
-  ensure sustainable withdrawals and supply of freshwater to address water scarcity
-  and substantially reduce the number of people suffering from water scarcity
+target_name: global_targets.6-4-title
 target_id: '6.4'
 un_custodian_agency: FAO
 un_designated_tier: '1'

--- a/meta/6-5-1.md
+++ b/meta/6-5-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 06-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, implement integrated water resources management at all levels, including
-  through transboundary cooperation as appropriate
+target_name: global_targets.6-5-title
 target_id: '6.5'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '1'

--- a/meta/6-5-2.md
+++ b/meta/6-5-2.md
@@ -11,8 +11,7 @@ indicator_sort_order: 06-05-02
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, implement integrated water resources management at all levels, including
-  through transboundary cooperation as appropriate
+target_name: global_targets.6-5-title
 target_id: '6.5'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute for Statistics (UNESCO-UIS) United Nations Economic Commission for Europe

--- a/meta/6-6-1.md
+++ b/meta/6-6-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 06-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2020, protect and restore water-related ecosystems, including mountains,
-  forests, wetlands, rivers, aquifers and lakes
+target_name: global_targets.6-6-title
 target_id: '6.6'
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/6-a-1.md
+++ b/meta/6-a-1.md
@@ -18,10 +18,7 @@ indicator_sort_order: 06-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, expand international cooperation and capacity-building support to
-  developing countries in water- and sanitation-related activities and programmes,
-  including water harvesting, desalination, water efficiency, wastewater treatment,
-  recycling and reuse technologies
+target_name: global_targets.6-a-title
 target_id: 6.a
 un_custodian_agency: World Health Organization (WHO) United Nations Environment Programme
   (UNEP) Organisation for Economic Co-operation and Development (OECD)

--- a/meta/6-b-1.md
+++ b/meta/6-b-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 06-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: Support and strengthen the participation of local communities in improving
-  water and sanitation management
+target_name: global_targets.6-b-title
 target_id: 6.b
 un_custodian_agency: WHO,UNEP, OECD
 un_designated_tier: '1'

--- a/meta/7-1-1.md
+++ b/meta/7-1-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 07-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '7'
-target: By 2030, ensure universal access to affordable, reliable and modern energy
-  services
+target_name: global_targets.7-1-title
 target_id: '7.1'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '1'

--- a/meta/7-1-2.md
+++ b/meta/7-1-2.md
@@ -18,8 +18,7 @@ indicator_sort_order: 07-01-02
 published: true
 reporting_status: notstarted
 sdg_goal: '7'
-target: By 2030, ensure universal access to affordable, reliable and modern energy
-  services
+target_name: global_targets.7-1-title
 target_id: '7.1'
 un_custodian_agency: International Trade Centre (ITC) United Nations Conference on
   Trade and Development (UNCTAD) The World Trade Organization (WTO)

--- a/meta/7-2-1.md
+++ b/meta/7-2-1.md
@@ -11,8 +11,7 @@ indicator_sort_order: 07-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '7'
-target: By 2030, increase substantially the share of renewable energy in the global
-  energy mix
+target_name: global_targets.7-2-title
 target_id: '7.2'
 un_custodian_agency: International Energy Agency (IEA) United Nations Statistics Division
   (UNSD) United Nations' inter-agency mechanism on energy (UN Energy) and the SE4ALL

--- a/meta/7-3-1.md
+++ b/meta/7-3-1.md
@@ -3,15 +3,15 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-07-03-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 192
   KB)
-graph_title:  Intensità energetica primaria
+graph_title: global_indicators.7-3-1-title
 graph_type: line
 indicator: 7.3.1
-indicator_name:  Intensità energetica primaria
+indicator_name: global_indicators.7-3-1-title
 indicator_sort_order: 07-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '7'
-target: Entro il 2030, raddoppiare il tasso globale di miglioramento dell'efficienza energetica
+target_name: global_targets.7-3-title
 target_id: '7.3'
 un_custodian_agency: International Energy Agency (IEA) United Nations Statistics Division
   (UNSD) United Nations' inter-agency mechanism on energy (UN Energy) and the SE4ALL

--- a/meta/7-a-1.md
+++ b/meta/7-a-1.md
@@ -13,10 +13,7 @@ indicator_sort_order: 07-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '7'
-target: By 2030, enhance international cooperation to facilitate access to clean energy
-  research and technology, including renewable energy, energy efficiency and advanced
-  and cleaner fossil-fuel technology, and promote investment in energy infrastructure
-  and clean energy technology
+target_name: global_targets.7-a-title
 target_id: 7.a
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '2'

--- a/meta/7-b-1.md
+++ b/meta/7-b-1.md
@@ -11,10 +11,7 @@ indicator_sort_order: 07-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '7'
-target: By 2030, expand infrastructure and upgrade technology for supplying modern
-  and sustainable energy services for all in developing countries, in particular least
-  developed countries, small island developing States and landlocked developing countries,
-  in accordance with their respective programmes of support
+target_name: global_targets.7-b-title
 target_id: 7.b
 un_custodian_agency: International Energy Agency (IEA)
 un_designated_tier: '3'

--- a/meta/8-1-1.md
+++ b/meta/8-1-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 08-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Sustain per capita economic growth in accordance with national circumstances
-  and, in particular, at least 7 per cent gross domestic product growth per annum
-  in the least developed countries
+target_name: global_targets.8-1-title
 target_id: '8.1'
 un_custodian_agency: United Nations Statistics Division (UNSD)
 un_designated_tier: '1'

--- a/meta/8-10-1.md
+++ b/meta/8-10-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 08-10-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Strengthen the capacity of domestic financial institutions to encourage and
-  expand access to banking, insurance and financial services for all
+target_name: global_targets.8-10-title
 target_id: '8.10'
 un_custodian_agency: IMF
 un_designated_tier: '1'

--- a/meta/8-10-2.md
+++ b/meta/8-10-2.md
@@ -10,9 +10,8 @@ indicator_sort_order: 08-10-02
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: 0 Strengthen the capacity of domestic financial institutions to encourage
-  and expand access to banking, insurance and financial services for all
-target_id: '8.1'
+target_name: global_targets.8-10-title
+target_id: '8.10'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '1'
 ---

--- a/meta/8-2-1.md
+++ b/meta/8-2-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 08-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Achieve higher levels of economic productivity through diversification, technological
-  upgrading and innovation, including through a focus on high-value added and labour-intensive
-  sectors
+target_name: global_targets.8-2-title
 target_id: '8.2'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '1'

--- a/meta/8-3-1.md
+++ b/meta/8-3-1.md
@@ -11,10 +11,7 @@ indicator_sort_order: 08-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Promote development-oriented policies that support productive activities,
-  decent job creation, entrepreneurship, creativity and innovation, and encourage
-  the formalization and growth of micro-, small- and medium-sized enterprises, including
-  through access to financial services
+target_name: global_targets.8-3-title
 target_id: '8.3'
 un_custodian_agency: International Labour Organisation (ILO)
 un_designated_tier: '2'

--- a/meta/8-4-1.md
+++ b/meta/8-4-1.md
@@ -11,10 +11,7 @@ indicator_sort_order: 08-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Improve progressively, through 2030, global resource efficiency in consumption
-  and production and endeavour to decouple economic growth from environmental degradation,
-  in accordance with the 10-Year Framework of Programmes on Sustainable Consumption
-  and Production, with developed countries taking the lead
+target_name: global_targets.8-4-title
 target_id: '8.4'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '3'

--- a/meta/8-4-2.md
+++ b/meta/8-4-2.md
@@ -11,10 +11,7 @@ indicator_sort_order: 08-04-02
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Improve progressively, through 2030, global resource efficiency in consumption
-  and production and endeavour to decouple economic growth from environmental degradation,
-  in accordance with the 10-Year Framework of Programmes on Sustainable Consumption
-  and Production, with developed countries taking the lead
+target_name: global_targets.8-4-title
 target_id: '8.4'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '1'

--- a/meta/8-5-1.md
+++ b/meta/8-5-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 08-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: 8.5 By 2030, achieve full and productive employment and decent work for all
-  women and men, including for young people and persons with disabilities, and equal
-  pay for work of equal value
+target_name: global_targets.8-5-title
 target_id: '8.5'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: 2

--- a/meta/8-5-2.md
+++ b/meta/8-5-2.md
@@ -21,9 +21,7 @@ indicator_sort_order: 08-05-02
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: By 2030, achieve full and productive employment and decent work for all women
-  and men, including for young people and persons with disabilities, and equal pay
-  for work of equal value
+target_name: global_targets.8-5-title
 target_id: '8.5'
 un_custodian_agency: International labour organization (ILO)
 un_designated_tier: '1'

--- a/meta/8-6-1.md
+++ b/meta/8-6-1.md
@@ -15,8 +15,7 @@ indicator_sort_order: 08-06-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: By 2020, substantially reduce the proportion of youth not in employment, education
-  or training
+target_name: global_targets.8-6-title
 target_id: '8.6'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '1'

--- a/meta/8-7-1.md
+++ b/meta/8-7-1.md
@@ -10,10 +10,7 @@ indicator_sort_order: 08-07-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Take immediate and effective measures to eradicate forced labour, end modern
-  slavery and human trafficking and secure the prohibition and elimination of the
-  worst forms of child labour, including recruitment and use of child soldiers, and
-  by 2025 end child labour in all its forms
+target_name: global_targets.8-7-title
 target_id: '8.7'
 un_custodian_agency: ILO,UNICEF
 un_designated_tier: '2'

--- a/meta/8-8-1.md
+++ b/meta/8-8-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 08-08-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Protect labour rights and promote safe and secure working environments for
-  all workers, including migrant workers, in particular women migrants, and those
-  in precarious employment
+target_name: global_targets.8-8-title
 target_id: '8.8'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '2'

--- a/meta/8-8-2.md
+++ b/meta/8-8-2.md
@@ -10,9 +10,7 @@ indicator_sort_order: 08-08-02
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: ' Protect labour rights and promote safe and secure working environments for
-  all workers, including migrant workers, in particular women migrants, and those
-  in precarious employment'
+target_name: global_targets.8-8-title
 target_id: '8.8'
 un_custodian_agency: ILO
 un_designated_tier: '3'

--- a/meta/8-9-1.md
+++ b/meta/8-9-1.md
@@ -13,8 +13,7 @@ indicator_sort_order: 08-09-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: By 2030, devise and implement policies to promote sustainable tourism that
-  creates jobs and promotes local culture and products
+target_name: global_targets.8-9-title
 target_id: '8.9'
 un_custodian_agency: World Tourism Organization (UNTWO)
 un_designated_tier: '2'

--- a/meta/8-9-2.md
+++ b/meta/8-9-2.md
@@ -11,8 +11,7 @@ indicator_sort_order: 08-09-02
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: By 2030, devise and implement policies to promote sustainable tourism that
-  creates jobs and promotes local culture and products
+target_name: global_targets.8-9-title
 target_id: '8.9'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '3'

--- a/meta/8-a-1.md
+++ b/meta/8-a-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 08-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Increase Aid for Trade support for developing countries, in particular least
-  developed countries, including through the Enhanced Integrated Framework for Trade-related
-  Technical Assistance to Least Developed Countries
+target_name: global_targets.8-a-title
 target_id: 8.a
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'

--- a/meta/8-b-1.md
+++ b/meta/8-b-1.md
@@ -10,8 +10,7 @@ indicator_sort_order: 08-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: By 2020, develop and operationalize a global strategy for youth employment
-  and implement the Global Jobs Pact of the International Labour Organization
+target_name: global_targets.8-b-title
 target_id: 8.b
 un_custodian_agency: ILO
 un_designated_tier: '3'

--- a/meta/9-1-1.md
+++ b/meta/9-1-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 09-01-01
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Develop quality, reliable, sustainable and resilient infrastructure, including
-  regional and trans-border infrastructure, to support economic development and human
-  well-being, with a focus on affordable and equitable access for all
+target_name: global_targets.9-1-title
 target_id: '9.1'
 un_custodian_agency: World Bank
 un_designated_tier: '3'

--- a/meta/9-1-2.md
+++ b/meta/9-1-2.md
@@ -11,9 +11,7 @@ indicator_sort_order: 09-01-02
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Develop quality, reliable, sustainable and resilient infrastructure, including
-  regional and trans-border infrastructure, to support economic development and human
-  well-being, with a focus on affordable and equitable access for all
+target_name: global_targets.9-1-title
 target_id: '9.1'
 un_custodian_agency: International Civil Aviation Organization (ICAO)
 un_designated_tier: '1'

--- a/meta/9-2-1.md
+++ b/meta/9-2-1.md
@@ -17,9 +17,7 @@ indicator_sort_order: 09-02-01
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Promote inclusive and sustainable industrialization and, by 2030, significantly
-  raise industry’s share of employment and gross domestic product, in line with national
-  circumstances, and double its share in least developed countries
+target_name: global_targets.9-2-title
 target_id: '9.2'
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '1'

--- a/meta/9-2-2.md
+++ b/meta/9-2-2.md
@@ -11,9 +11,7 @@ indicator_sort_order: 09-02-02
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Promote inclusive and sustainable industrialization and, by 2030, significantly
-  raise industry’s share of employment and gross domestic product, in line with national
-  circumstances, and double its share in least developed countries
+target_name: global_targets.9-2-title
 target_id: '9.2'
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '1'

--- a/meta/9-3-1.md
+++ b/meta/9-3-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 09-03-01
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Increase the access of small-scale industrial and other enterprises, in particular
-  in developing countries, to financial services, including affordable credit, and
-  their integration into value chains and markets
+target_name: global_targets.9-3-title
 target_id: '9.3'
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '2'

--- a/meta/9-3-2.md
+++ b/meta/9-3-2.md
@@ -10,9 +10,7 @@ indicator_sort_order: 09-03-02
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Increase the access of small-scale industrial and other enterprises, in particular
-  in developing countries, to financial services, including affordable credit, and
-  their integration into value chains and markets
+target_name: global_targets.9-3-title
 target_id: '9.3'
 un_custodian_agency: UNIDO,World Bank
 un_designated_tier: '2'

--- a/meta/9-4-1.md
+++ b/meta/9-4-1.md
@@ -11,10 +11,7 @@ indicator_sort_order: 09-04-01
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: By 2030, upgrade infrastructure and retrofit industries to make them sustainable,
-  with increased resource-use efficiency and greater adoption of clean and environmentally
-  sound technologies and industrial processes, with all countries taking action in
-  accordance with their respective capabilities
+target_name: global_targets.9-4-title
 target_id: '9.4'
 un_custodian_agency: International Energy Agency (IEA) United Nations Industrial Development
   Organization (UNIDO)

--- a/meta/9-5-1.md
+++ b/meta/9-5-1.md
@@ -11,10 +11,7 @@ indicator_sort_order: 09-05-01
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Enhance scientific research, upgrade the technological capabilities of industrial
-  sectors in all countries, in particular developing countries, including, by 2030,
-  encouraging innovation and substantially increasing the number of research and development
-  workers per 1 million people and public and private research and development spending
+target_name: global_targets.9-5-title
 target_id: '9.5'
 un_custodian_agency: United Nations Educational Scientific and Cultural Organization
   (UNESCO)

--- a/meta/9-5-2.md
+++ b/meta/9-5-2.md
@@ -11,10 +11,7 @@ indicator_sort_order: 09-05-02
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Enhance scientific research, upgrade the technological capabilities of industrial
-  sectors in all countries, in particular developing countries, including, by 2030,
-  encouraging innovation and substantially increasing the number of research and development
-  workers per 1 million people and public and private research and development spending
+target_name: global_targets.9-5-title
 target_id: '9.5'
 un_custodian_agency: United Nations Educational Scientific and Cultural Organization
   (UNESCO)

--- a/meta/9-a-1.md
+++ b/meta/9-a-1.md
@@ -13,10 +13,7 @@ indicator_sort_order: 09-aa-01
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Facilitate sustainable and resilient infrastructure development in developing
-  countries through enhanced financial, technological and technical support to African
-  countries, least developed countries, landlocked developing countries and small
-  island developing States
+target_name: global_targets.9-a-title
 target_id: 9.a
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'

--- a/meta/9-b-1.md
+++ b/meta/9-b-1.md
@@ -11,9 +11,7 @@ indicator_sort_order: 09-bb-01
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Support domestic technology development, research and innovation in developing
-  countries, including by ensuring a conducive policy environment for, inter alia,
-  industrial diversification and value addition to commodities
+target_name: global_targets.9-b-title
 target_id: 9.b
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '1'

--- a/meta/9-c-1.md
+++ b/meta/9-c-1.md
@@ -10,9 +10,7 @@ indicator_sort_order: 09-cc-01
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Significantly increase access to information and communications technology
-  and strive to provide universal and affordable access to the Internet in least developed
-  countries by 2020
+target_name: global_targets.9-c-title
 target_id: 9.c
 un_custodian_agency: ITU
 un_designated_tier: '1'


### PR DESCRIPTION
@mauromussin This fixes a bug that was preventing the target name from displaying in the "Global Metadata" tab. Apparently we can't use "target", so this changes it to "target_name". Also this changes them all to the "translation key" so that they will be translated.