### PR TITLE
Point to latest versions of translations

### DIFF
--- a/config_data.yml
+++ b/config_data.yml
@@ -17,6 +17,6 @@ src_dir: ''
 
 # Links to Git repositories with translation data.
 translations:
-  - https://github.com/mauromussin/translations-open-sdg.git@1.0.0-rc8
-  - https://github.com/mauromussin/translations-un-sdg.git@1.0.0-rc3
+  - https://github.com/mauromussin/translations-open-sdg.git
+  - https://github.com/mauromussin/translations-un-sdg.git
 


### PR DESCRIPTION
@mauromussin This points to the latest versions of your custom translations, rather than pinning to tags. Long-term, it's probably better to pin to tags, but for now during development, using the latest code might be simpler.

Also, if you are maintaining the translations at the remote Git repositories, then you technically don't need to have them here in this repo. So, as long as you have everything updated [here](https://github.com/mauromussin/translations-un-sdg) and [here](https://github.com/mauromussin/translations-open-sdg), you can delete the contents of the "translations" folder in this repo.

Last note - you might have expected that your local translations would have overridden the remote translations. That would have seemed logical to me, but apparently it doesn't work like that. I've submitted a bug report and opened an issue about that problem [here](https://github.com/open-sdg/sdg-build/issues/118).